### PR TITLE
ADH-5681

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -453,7 +453,7 @@ class CompactionTxnHandler extends TxnHandler {
   @Override
   @RetrySemantics.CannotRetry
   public void setCleanerRetryRetentionTimeOnError(CompactionInfo info) throws MetaException {
-    String sanitizedErrorMessage = info.errorMessage == null ? null : info.errorMessage.replace("\0", "");
+    String sanitizedErrorMessage = TxnUtils.utf8Sanitize(info.errorMessage);
     if (info.isAbortedTxnCleanup() && info.id == 0) {
       /*
        * MUTEX_KEY.CompactionScheduler lock ensures that there is only 1 entry in

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -453,6 +453,7 @@ class CompactionTxnHandler extends TxnHandler {
   @Override
   @RetrySemantics.CannotRetry
   public void setCleanerRetryRetentionTimeOnError(CompactionInfo info) throws MetaException {
+    String sanitizedErrorMessage = info.errorMessage == null ? null : info.errorMessage.replace("\0", "");
     if (info.isAbortedTxnCleanup() && info.id == 0) {
       /*
        * MUTEX_KEY.CompactionScheduler lock ensures that there is only 1 entry in
@@ -473,7 +474,7 @@ class CompactionTxnHandler extends TxnHandler {
                 .addValue("type", Character.toString(thriftCompactionType2DbType(info.type)))
                 .addValue("state", Character.toString(info.state))
                 .addValue("retention", info.retryRetention)
-                .addValue("msg", info.errorMessage), null);
+                .addValue("msg", sanitizedErrorMessage), null);
         if (updCnt == 0) {
           LOG.error("Unable to update/insert compaction queue record: {}. updCnt={}", info, updCnt);
           throw new MetaException("Unable to insert abort retry entry into COMPACTION QUEUE: " +
@@ -487,7 +488,7 @@ class CompactionTxnHandler extends TxnHandler {
           "UPDATE \"COMPACTION_QUEUE\" SET \"CQ_RETRY_RETENTION\" = :retention, \"CQ_ERROR_MESSAGE\"= :msg WHERE \"CQ_ID\" = :id",
           new MapSqlParameterSource()
               .addValue("retention", info.retryRetention)
-              .addValue("msg", info.errorMessage)
+              .addValue("msg", sanitizedErrorMessage)
               .addValue("id", info.id),
           ParameterizedCommand.EXACTLY_ONE_ROW);
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnUtils.java
@@ -696,4 +696,8 @@ public class TxnUtils {
     sb.append(") values (" + placeholder + ")");
     return sb.toString();
   }
+
+  public static String utf8Sanitize(String input) {
+    return input == null ? null : input.replace("\0", "");
+  }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/MarkCleanedFunction.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/jdbc/functions/MarkCleanedFunction.java
@@ -122,9 +122,9 @@ public class MarkCleanedFunction implements TransactionalFunction<Void> {
 
     MapSqlParameterSource params = new MapSqlParameterSource()
         .addValue("state", TxnStatus.ABORTED.getSqlConst(), Types.CHAR)
-        .addValue("db", info.dbname)
-        .addValue("table", info.tableName)
-        .addValue("partition", info.partName);
+        .addValue("db", info.dbname, Types.VARCHAR)
+        .addValue("table", info.tableName, Types.VARCHAR)
+        .addValue("partition", info.partName, Types.VARCHAR);
 
     int totalCount = 0;
     if (!info.hasUncompactedAborts && info.highestWriteId != 0) {


### PR DESCRIPTION
fix(ADH-5681): Explicitly specify SQL types for db, table, and partition parameters in removeTxnComponents for compaction.
fix(ADH-5681): Sanitize error message in compaction queue update.
fix(ADH-5681): generate utf8Sanitize utility method and use it in CompactionTxnHandler.